### PR TITLE
Port plugin to ES6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/Plumbing.js
+++ b/Plumbing.js
@@ -6,7 +6,7 @@
 
 var all       = require('plumber-all');
 var glob      = require('plumber-glob');
-var requireJS = require('plumber-requirejs');
+var traceur   = require('plumber-traceur');
 var uglifyJS  = require('plumber-uglifyjs');
 var write     = require('plumber-write');
 
@@ -20,7 +20,7 @@ module.exports = function (pipelines) {
 
   pipelines['build'] = [
     glob('src/scribe-plugin-heading-command.js'),
-    requireJS(),
+    traceur.toAmd(),
     writeBoth
   ];
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "plumber": "~0.3.0",
     "plumber-all": "~0.3.0",
     "plumber-glob": "~0.3.0",
-    "plumber-requirejs": "~0.3.0",
     "plumber-uglifyjs": "~0.3.0",
     "plumber-write": "~0.3.0",
     "plumber-traceur": "~0.3.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "plumber-glob": "~0.3.0",
     "plumber-requirejs": "~0.3.0",
     "plumber-uglifyjs": "~0.3.0",
-    "plumber-write": "~0.3.0"
+    "plumber-write": "~0.3.0",
+    "plumber-traceur": "~0.3.2"
   },
   "repository": {
     "type": "git",

--- a/src/scribe-plugin-heading-command.js
+++ b/src/scribe-plugin-heading-command.js
@@ -1,54 +1,51 @@
-define(function () {
 
-  /**
-   * This plugin adds a command for headings.
-   */
+/**
+ * This plugin adds a command for headings.
+ */
 
-  'use strict';
-
-  return function (level) {
+function headingCommandPlugin(level) {
     return function (scribe) {
-      var tag = '<h' + level + '>';
-      var nodeName = 'H' + level;
-      var commandName = 'h' + level;
+        var tag = '<h' + level + '>';
+        var nodeName = 'H' + level;
+        var commandName = 'h' + level;
 
-      /**
-       * Chrome: the `heading` command doesn't work. Supported by Firefox only.
-       */
+        /**
+         * Chrome: the `heading` command doesn't work. Supported by Firefox only.
+         */
 
-      var headingCommand = new scribe.api.Command('formatBlock');
+        var headingCommand = new scribe.api.Command('formatBlock');
 
-      headingCommand.execute = function () {
-        if (this.queryState()) {
-          scribe.api.Command.prototype.execute.call(this, '<p>');
-        } else {
-          scribe.api.Command.prototype.execute.call(this, tag);
-        }
-      };
+        headingCommand.execute = function () {
+            if (this.queryState()) {
+                scribe.api.Command.prototype.execute.call(this, '<p>');
+            } else {
+                scribe.api.Command.prototype.execute.call(this, tag);
+            }
+        };
 
-      headingCommand.queryState = function () {
-        var selection = new scribe.api.Selection();
-        return !! selection.getContaining(function (node) {
-          return node.nodeName === nodeName;
-        });
-      };
+        headingCommand.queryState = function () {
+            var selection = new scribe.api.Selection();
+            return !! selection.getContaining(function (node) {
+                return node.nodeName === nodeName;
+            });
+        };
 
-      /**
-       * All: Executing a heading command inside a list element corrupts the markup.
-       * Disabling for now.
-       */
-      headingCommand.queryEnabled = function () {
-        var selection = new scribe.api.Selection();
-        var listNode = selection.getContaining(function (node) {
-          return node.nodeName === 'OL' || node.nodeName === 'UL';
-        });
+        /**
+         * All: Executing a heading command inside a list element corrupts the markup.
+         * Disabling for now.
+         */
+        headingCommand.queryEnabled = function () {
+            var selection = new scribe.api.Selection();
+            var listNode = selection.getContaining(function (node) {
+                return node.nodeName === 'OL' || node.nodeName === 'UL';
+            });
 
-        return scribe.api.Command.prototype.queryEnabled.apply(this, arguments)
-          && scribe.allowsBlockElements() && ! listNode;
-      };
+            return scribe.api.Command.prototype.queryEnabled.apply(this, arguments)
+                && scribe.allowsBlockElements() && ! listNode;
+        };
 
-      scribe.commands[commandName] = headingCommand;
+        scribe.commands[commandName] = headingCommand;
     };
-  };
+};
 
-});
+export default headingCommandPlugin;


### PR DESCRIPTION
Proof-of-concept attempt to convert this plugin from AMD to ES6 module.

Note:
- As I was going to reindent the code, I ported it to 4-spaces, which I think we wanted to make standard across the codebase?
- The output AMD module (from plumber build) looks a bit funky, with ES5 getter based defaults. From what I can Google, that should be [supported by all modern browsers](http://kangax.github.io/compat-table/es5/#Getter_in_property_initializer) (but excluding IE7-8).
- It'd be good to prove that the output of `traceur.toCommonJs()` works fine for people who live in browserifyland.
