### PR TITLE
Added Shadow DOM support with WebComponents polyfill

### DIFF
--- a/src/scribe-plugin-heading-command.js
+++ b/src/scribe-plugin-heading-command.js
@@ -1,4 +1,4 @@
-define(function (useAlternativeImplementation) {
+define(function () {
 
   /**
    * This plugin adds a command for headings.
@@ -6,7 +6,7 @@ define(function (useAlternativeImplementation) {
 
   'use strict';
 
-  return function (level) {
+  return function (level, useAlternativeImplementation) {
     return function (scribe) {
       var tagName = 'h' + level;
       var tag = '<' + tagName + '>';

--- a/src/scribe-plugin-heading-command.js
+++ b/src/scribe-plugin-heading-command.js
@@ -31,7 +31,7 @@ define(function () {
             if (nodeToReplace.nodeName == nodeName) {
               newNode = document.createElement('p');
             } else {
-              newNode = document.createElement(tag);
+              newNode = document.createElement(tagName);
             }
             newNode.innerHTML = nodeToReplace.innerHTML;
             nodeToReplace.parentNode.replaceChild(newNode, nodeToReplace);


### PR DESCRIPTION
It was broken with WebComponents polyfill in Firefox (`document.execCommand('formatBlock', ...)` call to be precise.
Now optional alternative implementation is added and it works under Shadow DOM even when using WebComponents polyfill.
